### PR TITLE
Fix Password Input which allow user to hide password

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -5,6 +5,13 @@ import React from 'react'
 const _layout = () => {
   return (
     <Stack >
+            <Stack.Screen name= "index"
+            options={{
+                headerTitle: "splash screen",
+                headerShown: false,
+                headerStyle: {}
+            }}
+          />
         <Stack.Screen name= "screens/Home/parking/index"
             options={{
                 headerTitle: "splash screen",
@@ -77,12 +84,6 @@ const _layout = () => {
             }}
       />
 
-      {/* <Stack.Screen name= "screens/Home/HomeView"
-                      options={{
-                      headerTitle: "",
-                      headerShown: false,
-                  }}
-          /> */}
            <Stack.Screen name= "screens/Home/ProfileScreen"
                       options={{
                       headerTitle: "",
@@ -165,13 +166,6 @@ const _layout = () => {
                     headerShown: false,
                 }}
             />
-
-            {/* <Stack.Screen name= "screens/Home/parking/homeScreen"
-                    options={{
-                    headerTitle: "",
-                    headerShown: false,
-                }}
-            /> */}
     </Stack>
   )
 }

--- a/src/app/screens/Auth/EmailLoginScreen.tsx
+++ b/src/app/screens/Auth/EmailLoginScreen.tsx
@@ -10,6 +10,7 @@ import {
 } from "react-native";
 import Input from "../../../components/Input";
 import LoginButton from "../../../components/LoginButton";
+import PasswordInput from "../../../components/PasswordInput";
 import { COLORS } from "../../../constants";
 import { useState } from "react";
 import { Link, router } from "expo-router";
@@ -63,12 +64,7 @@ function EmailLoginScreen() {
               onChangeText={(newText) => setEmail(newText)}
               value={email}
             />
-            <TextInput
-              style={{ padding: 15, backgroundColor: "#fff", width: "65%",borderRadius: 10,marginBottom: 20 }}
-              placeholder="Password"
-              onChangeText={setPassword}
-              value={password}
-            />
+              <PasswordInput text="Password" onChangeText={newText =>setPassword(newText)}  value={password}password={password} setPassword={setPassword}/>
             <View style={styles.Forget}>
               <Text style={styles.ForgetText}>
                 Forget password?{" "}

--- a/src/app/screens/Auth/PhoneScreenLogin.tsx
+++ b/src/app/screens/Auth/PhoneScreenLogin.tsx
@@ -26,7 +26,7 @@ function PhoneScreenLogin() {
                 <View style={styles.ViewInput}>
                 <PhoneNumberInput/>
                 
-                 <PasswordInput text="Password" onChangeText={newText =>setPassword(newText)}  value={password} />
+                <PasswordInput text="Password" onChangeText={newText =>setPassword(newText)}  value={password}password={password} setPassword={setPassword}/>
                     <View style={styles.Forget}>
                         <Text style={styles.forgetText}>Forget password? <Link href="/screens/Auth/ForgetPasswordScreen"><Text style={styles.retrieve}>Retrieve</Text></Link></Text>
                     </View>    

--- a/src/app/screens/Auth/RegisterScreen.tsx
+++ b/src/app/screens/Auth/RegisterScreen.tsx
@@ -42,7 +42,7 @@ function RegisterScreen() {
                <View style={styles.ViewInput}>
                     <Input text="Email" onChangeText={setEmail} value={email} />
                     
-                    <PasswordInput text="Password" onChangeText={newText => setPassword(newText)}  value={password}/>
+                  <PasswordInput text="Password" onChangeText={newText =>setPassword(newText)}  value={password}password={password} setPassword={setPassword}/>
                     <Input text="Password Authentication"  onChangeText={newText =>setPassword(newText)}  value={password} />
                         <Input text="Phone Number" onChangeText={setPhoneNumber} value={phoneNumber} />
                         

--- a/src/components/PasswordInput.tsx
+++ b/src/components/PasswordInput.tsx
@@ -6,14 +6,16 @@ import { Feather } from '@expo/vector-icons';
 
 interface PasswordProps{
     onChangeText: (text: string) => void
-    value:string
-    text:string
+    value:string,
+    text: string,
+    password: string,
+    setPassword:React.Dispatch<React.SetStateAction<string>>
 }
 
 
 
-function PasswordInput({text}:PasswordProps) {
-    const [password, setPassword] = useState('')
+function PasswordInput({text,password,setPassword}:PasswordProps) {
+   
     const [showPassword, setShowPassword] = useState(false)
    
     


### PR DESCRIPTION
## What does this PR do?
This pull request enhances the password input functionality within our application, allowing users to hide or show their passwords as they type. This update aims to improve user security and interface friendliness.

## Description of Task to be completed?
Password Visibility Toggle: Implement a toggle feature that allows users to switch between hiding and showing their passwords on the login and registration screens. This involves updating the UI components and ensuring they function correctly across all devices.
Enhanced Security: By allowing users to hide their passwords, we reduce the risk of shoulder surfing and unauthorized access in public or shared spaces.
## How should this be manually tested?
Setup: Ensure your development environment is set up to run React Native applications. This can include setting up Android Studio, Xcode, or using the Expo CLI.
Run the App: Launch the application on your emulator or a physical device.
Test Password Visibility:
Navigate to the login or registration screen.
Enter a password in the password field.
Use the toggle (typically an eye icon) to switch between showing and hiding the password.
Verify that the toggle correctly shows and hides the password and that the password field behaves consistently across different device configurations.
## What are the relevant pivotal tracker stories?
[Trello(https://trello.com/c/5bSLHD21)]